### PR TITLE
Removed the dead SQL Server 2019 extension download link.

### DIFF
--- a/Hands-on lab/Before the HOL - Modernizing Data Analytics with SQL Server 2019.md
+++ b/Hands-on lab/Before the HOL - Modernizing Data Analytics with SQL Server 2019.md
@@ -54,7 +54,6 @@ Microsoft and the trademarks listed at <https://www.microsoft.com/en-us/legal/in
 8. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-with-powershell-from-psgallery)
 9. [SQL Server Management Studio](https://go.microsoft.com/fwlink/?linkid=2078638) (SSMS) v18.0 or greater
 10. [Azure Data Studio](https://docs.microsoft.com/sql/azure-data-studio/download?view=sql-server-ver15)
-    - [SQL Server 2019 extension](https://docs.microsoft.com/en-us/sql/azure-data-studio/sql-server-2019-extension?view=sql-server-2017)
 
 ## Preview requirements
 


### PR DESCRIPTION
The extension is now bundled with the November release.

https://cloudblogs.microsoft.com/sqlserver/2019/11/05/the-november-2019-release-of-azure-data-studio-is-now-available/



